### PR TITLE
Prevent update when nothing change on Entities with class inheritance

### DIFF
--- a/Tests/Functional/fixtures/Entity/ClassTableInheritanceBase.php
+++ b/Tests/Functional/fixtures/Entity/ClassTableInheritanceBase.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Ambta\DoctrineEncryptBundle\Tests\Functional\fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorColumn(name="discr", type="string")
+ */
+class ClassTableInheritanceBase
+{
+
+    /**
+     * @var int
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @Ambta\DoctrineEncryptBundle\Configuration\Encrypted()
+     * @ORM\Column(type="string", nullable=true)
+     */
+    private $secretBase;
+
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
+    private $notSecretBase;
+
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getSecretBase()
+    {
+        return $this->secretBase;
+    }
+
+    public function setSecretBase($secretBase)
+    {
+        $this->secretBase = $secretBase;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getNotSecretBase()
+    {
+        return $this->notSecretBase;
+    }
+
+    /**
+     * @param mixed $notSecretBase
+     */
+    public function setNotSecretBase($notSecretBase)
+    {
+        $this->notSecretBase = $notSecretBase;
+    }
+
+}

--- a/Tests/Functional/fixtures/Entity/ClassTableInheritanceChild.php
+++ b/Tests/Functional/fixtures/Entity/ClassTableInheritanceChild.php
@@ -1,0 +1,49 @@
+<?php
+
+
+namespace Ambta\DoctrineEncryptBundle\Tests\Functional\fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity */
+class ClassTableInheritanceChild extends ClassTableInheritanceBase
+{
+
+    /**
+     * @Ambta\DoctrineEncryptBundle\Configuration\Encrypted()
+     * @ORM\Column(type="string", nullable=true)
+     */
+    private $secretChild;
+
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
+    private $notSecretChild;
+
+    public function getSecretChild()
+    {
+        return $this->secretChild;
+    }
+
+    public function setSecretChild($secretChild)
+    {
+        $this->secretChild = $secretChild;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getNotSecretChild()
+    {
+        return $this->notSecretChild;
+    }
+
+    /**
+     * @param mixed $notSecretChild
+     */
+    public function setNotSecretChild($notSecretChild)
+    {
+        $this->notSecretChild = $notSecretChild;
+    }
+
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
             <directory suffix="Test.php">./Tests/Unit</directory>
         </testsuite>
         <testsuite name="functional">
-            <directory suffix="Test.php">./Tests/Functional</directory>
+            <directory suffix="TestCase.php">./Tests/Functional</directory>
         </testsuite>
     </testsuites>
 

--- a/src/Subscribers/DoctrineEncryptSubscriber.php
+++ b/src/Subscribers/DoctrineEncryptSubscriber.php
@@ -158,11 +158,9 @@ class DoctrineEncryptSubscriber implements EventSubscriber
     public function preFlush(PreFlushEventArgs $preFlushEventArgs)
     {
         $unitOfWOrk = $preFlushEventArgs->getEntityManager()->getUnitOfWork();
-        foreach ($unitOfWOrk->getIdentityMap() as $entityName => $entityArray) {
-            if (isset($this->cachedDecryptions[$entityName])) {
-                foreach ($entityArray as $entityId => $instance) {
-                    $this->processFields($instance);
-                }
+        foreach ($unitOfWOrk->getIdentityMap() as $entityArray) {
+            foreach ($entityArray as $entityId => $instance) {
+                $this->processFields($instance);
             }
         }
         $this->cachedDecryptions = [];
@@ -260,13 +258,13 @@ class DoctrineEncryptSubscriber implements EventSubscriber
                                 $this->decryptCounter++;
                                 $currentPropValue = $this->encryptor->decrypt(substr($value, 0, -5));
                                 $pac->setValue($entity, $refProperty->getName(), $currentPropValue);
-                                $this->cachedDecryptions[get_class($entity)][spl_object_id($entity)][$refProperty->getName()][$currentPropValue] = $value;
+                                $this->cachedDecryptions[$realClass][spl_object_id($entity)][$refProperty->getName()][$currentPropValue] = $value;
                             }
                         }
                     } else {
                         if (!is_null($value) and !empty($value)) {
-                            if (isset($this->cachedDecryptions[get_class($entity)][spl_object_id($entity)][$refProperty->getName()][$value])) {
-                                $pac->setValue($entity, $refProperty->getName(), $this->cachedDecryptions[get_class($entity)][spl_object_id($entity)][$refProperty->getName()][$value]);
+                            if (isset($this->cachedDecryptions[$realClass][spl_object_id($entity)][$refProperty->getName()][$value])) {
+                                $pac->setValue($entity, $refProperty->getName(), $this->cachedDecryptions[$realClass][spl_object_id($entity)][$refProperty->getName()][$value]);
                             } elseif (substr($value, -strlen(self::ENCRYPTION_MARKER)) != self::ENCRYPTION_MARKER) {
                                 $this->encryptCounter++;
                                 $currentPropValue = $this->encryptor->encrypt($value).self::ENCRYPTION_MARKER;


### PR DESCRIPTION
Related to #25, #28 & #35. 

The implementation didn't handle Entities using class inheritance correctly as the Unit Of Work Identity Map entity name will refer to the root class of an Entity which uses inheritance but the cached decryptions array did not use the same reference.

This change adds tests for the scenario and provides a fix. 

It also re-enables tests that were accidentally disabled by renaming the functional test cases from `*Test.php` to `*TestCase.php` in #36 which meant they were not picked up by the filter in phpunit.xml.dist.