### PR TITLE
Fixed the determination of the entity class name (for proxied classes) used as key in $cachedDecryptions

### DIFF
--- a/Tests/Unit/DependencyInjection/DoctrineEncryptExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/DoctrineEncryptExtensionTest.php
@@ -26,7 +26,7 @@ class DoctrineEncryptExtensionTest extends TestCase
         $container = $this->createContainer();
         $this->extension->load([[]], $container);
 
-        $this->assertSame(HaliteEncryptor::class, $container->getParameter('ambta_doctrine_encrypt.encryptor_class_name'));
+        self::assertSame(HaliteEncryptor::class, $container->getParameter('ambta_doctrine_encrypt.encryptor_class_name'));
     }
 
     public function testConfigLoadDefuse()
@@ -38,7 +38,7 @@ class DoctrineEncryptExtensionTest extends TestCase
         ];
         $this->extension->load([$config], $container);
 
-        $this->assertSame(DefuseEncryptor::class, $container->getParameter('ambta_doctrine_encrypt.encryptor_class_name'));
+        self::assertSame(DefuseEncryptor::class, $container->getParameter('ambta_doctrine_encrypt.encryptor_class_name'));
     }
 
     public function testConfigLoadCustom()
@@ -49,17 +49,15 @@ class DoctrineEncryptExtensionTest extends TestCase
         ];
         $this->extension->load([$config], $container);
 
-        $this->markTestSkipped();
+        self::markTestSkipped();
 
-        $this->assertSame(self::class, $container->getParameter('ambta_doctrine_encrypt.encryptor_class_name'));
+        self::assertSame(self::class, $container->getParameter('ambta_doctrine_encrypt.encryptor_class_name'));
     }
 
     private function createContainer()
     {
-        $container = new ContainerBuilder(
+        return new ContainerBuilder(
             new ParameterBag(['kernel.debug' => false])
         );
-
-        return $container;
     }
 }

--- a/src/Command/DoctrineEncryptDatabaseCommand.php
+++ b/src/Command/DoctrineEncryptDatabaseCommand.php
@@ -84,7 +84,7 @@ class DoctrineEncryptDatabaseCommand extends AbstractCommand
             $output->writeln(sprintf('Processing <comment>%s</comment>', $metaData->name));
             $progressBar = new ProgressBar($output, $totalCount);
             foreach ($iterator as $row) {
-                $this->subscriber->processFields($row[0]);
+                $this->subscriber->processFields($row[0], $this->entityManager);
 
                 if (($i % $batchSize) === 0) {
                     $this->entityManager->flush();


### PR DESCRIPTION
- Fixed the determination of the entity class name (for proxied classes) used as key in $cachedDecryptions
Before the fix, entities were sometimes decrypted and encrypted several times in certain situations, even though only read operations took place. This led to unnecessary write operations and thus to incorrect date changes (last_changed) if such an attribute exists in the data model.

- Changed coding in some places to follow best practices 
- Removed unnecessary !is_null() check where !empty() was in use too
- Replaced -5 with -strlen(self::ENCRYPTION_MARKER)