### PR TITLE
Fix name in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "absolute-quantum/doctrine-encrypt-bundle",
+	"name": "michaeldegroot/doctrine-encrypt-bundle",
 	"type": "library",
 	"keywords": ["doctrine", "symfony", "halite", "defuse", "encrypt", "decrypt"],
 	"license": "MIT",


### PR DESCRIPTION
The package is registered on packagist as michaeldegroot/doctrine-encrypt-bundle on packagist not absolute-quantum/doctrine-encrypt-bundle. Looks like somebody misinterpreted it that it need to be the github name but that is incorrect.

I even would not recommend rename a package as it loses then its stats else.

https://packagist.org/packages/michaeldegroot/doctrine-encrypt-bundle

