### PR TITLE
Remove redundant paragonie/sodium_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
 	"require": {
 		"php": "^8.0",
 		"paragonie/halite": "^4.6",
-		"paragonie/sodium_compat": "^1.5",
 		"doctrine/orm": "^2.5",
 		"symfony/property-access": "^4.1|^5.0|^6.0",
 		"symfony/dependency-injection": "^4.1|^5.0|^6.0",


### PR DESCRIPTION
This package depends on `paragonie/sodium_compat: ^1.5`, but also `php: ^8.0`. Since `libsodium` was added in PHP 7.2, the dependency on `paragonie/sodium_compat` seems redundant?